### PR TITLE
Refactor: Updated build.yml to version 3 of actions. Added npm caching according to the GitHub documentation.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,16 +14,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check out code 🛎
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Node v17
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "17.x"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Cache node modules
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - if: ${{ steps.cache-npm.outputs.cache-hit == 'false' }}
+        name: List the state of node modules
+        continue-on-error: true
+        run: npm list
+
       - name: Install dependencies
-        run: npm install --force
+        run: npm install
 
       - name: Run prettier
         run: npm run format-check
@@ -33,3 +52,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Test
+        run: npm run test


### PR DESCRIPTION
Updated to version 3 of actions. Added npm caching according to the GitHub documentation. Rearranged steps and added one more step to reflect how it is done in the documentation. The first job will generate the cache, every subsequent job will then use that cache instead of downloading the npm packages every time. Please refrain from using "--force" if possible.

The official documentation for this can be found [here](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#output-parameters-for-the-cache-action). 

I have tested and verified this by running GitHub actions on my own fork multiple times to check if the cache is working. The first trigger (by the commit) installed the npm packages in 32 seconds and generated the cache afterwards. The entire job took roughly 1 minute and 21 seconds to complete. Re-running the job made use of the cache and installed the packages in just 9-10 seconds. The total job time this subsequent run was under a minute, roughly 54 seconds. I added two screenshots as "proof" (see "Install dependencies" step). The caching won't always be saving this much time, but it will always save some time overall. It seems to depend on the runner that is assigned to do the job. I can say from my work experience that not all runners are equal.

Screenshots:
![Run_1](https://user-images.githubusercontent.com/53854947/183714720-ff442a70-b8ca-478a-a5e7-abd51951fa1c.png)


![Run_2](https://user-images.githubusercontent.com/53854947/183714739-72a11a08-a72d-45ef-bf03-fa49058125a9.png)


IMPORTANT: The step "List the state of node modules" seems to be optional and can be removed if you wish. See [here](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#using-the-output-of-the-cache-action) for more information. I just left it in because it was part of the example in the documentation.

-The new guy, Adri#1998


